### PR TITLE
Update StashInsight.stoverride

### DIFF
--- a/rewrite/StashInsight.stoverride
+++ b/rewrite/StashInsight.stoverride
@@ -42,6 +42,7 @@ tiles:
     icon: 'arrow.up.arrow.down.circle.fill'
     backgroundColor: '#4CAF50'
     argument: 'Stash iOS,tile,http://localhost:9090/connections,,stash'
+    url: 'http://clash.insight:9090/html'
 
 script-providers:
   clash-insight:


### PR DESCRIPTION
Tile 现已支持 URL 参数，可直接从 Tile 跳转到 insight 网页。